### PR TITLE
chore: add a build schedule duration

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -3,6 +3,8 @@ name: 'Build, Test, Deploy'
 on:
   pull_request: #{ types: [ready_for_review] }
   push: { branches: [main] }
+  schedule:
+    - cron: "36 */5 * * *"
   #release: { types: [published] }
 
 concurrency:


### PR DESCRIPTION
Adds the ~ 5 hours schedule duration for build & re-deploy