### PR TITLE
[FIX] husky added to tar

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -161,6 +161,7 @@ jobs:
             next.config.js \
             package-lock.json \
             package.json \
+            husky.js \
             /tmp/.github_sha \
             /tmp/.github_ref
 


### PR DESCRIPTION
This pr will add husky.js to tar. It will fix husky.js not found error in the deploy script.