### PR TITLE
Added .env file with default environment variables

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,17 @@
+# Publicly Accessible Discourse Host URL (Frontend use)
+# This URL is accessible on the client side and can be used for rendering the Discourse forums
+NEXT_PUBLIC_DISCOURSE_HOST = 'https://forums.rocket.chat'
+
+# Discourse Host URL (Backend use)
+# This URL is for server-side use and can be used to fetch data or interact with the Discourse API
+DISCOURSE_HOST='https://forums.rocket.chat'
+
+# GSOC Leaderboard Base URL
+# This URL is used as the base to fetch or interact with the GSOC leaderboard API
+GSOC_LEADERBOARD_BASE_URL='https://gsoc.rocket.chat'
+
+# Added custom environment variables below
+# Base URL for custom image storage
+IMAGE_STORAGE_URL='https://storage.example.com'
+
+

--- a/.gitignore
+++ b/.gitignore
@@ -73,7 +73,7 @@ web_modules/
 .yarn-integrity
 
 # dotenv environment variable files
-.env
+# .env
 .env.development.local
 .env.test.local
 .env.production.local


### PR DESCRIPTION
Hi Team, 👋

I’ve added a default .env file as per the issue requirements. The file includes:

Existing Variables:

NEXT_PUBLIC_DISCOURSE_HOST: Public URL for Discourse forums.
DISCOURSE_HOST: Backend URL for Discourse forums.
GSOC_LEADERBOARD_BASE_URL: Base URL for the GSOC leaderboard.
Placeholder for New Variables:
A comment indicating where contributors can add custom environment variables.
Explanatory Comments:
Added comments explaining the purpose of the variables.